### PR TITLE
Correctly get post attachment from attachment ids list

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Not released
+### Fixed
+- Correctly get post attachment from attachment ids list. Fixes [#26](https://github.com/devgeniem/wp-geniem-importer/issues/26)
+
 ## Released
 
 ## [1.0.1] - 2020-03-04

--- a/src/Post.php
+++ b/src/Post.php
@@ -958,7 +958,8 @@ class Post {
                     }
 
                     // If attachment id exists
-                    $attachment_post_id = $this->attachment_ids[ $value ] ?? '';
+                    $attachment_prefix  = Settings::get('attachment_prefix');
+                    $attachment_post_id = $this->attachment_ids[  $attachment_prefix  . $value ] ?? '';
 
                     // If not empty set _thumbnail_id
                     if ( ! empty( $attachment_post_id ) ) {


### PR DESCRIPTION
### Fixed
- Correctly get post attachment from attachment ids list. Fixes #26 